### PR TITLE
채널로 분기, destination 분기 테스트

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
 	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 	//implementation("org.springframework.cloud:spring-cloud-stream")
 	// nats
-
+	implementation("io.nats:nats-spring-boot-starter:0.5.0")
 	implementation("io.nats:nats-spring-cloud-stream-binder:0.5.0")
 	implementation("io.nats:nats-spring:0.5.0")
 

--- a/src/main/kotlin/com/demo/nats/binder/AccountProcess.kt
+++ b/src/main/kotlin/com/demo/nats/binder/AccountProcess.kt
@@ -1,0 +1,31 @@
+package com.demo.nats.binder
+
+import org.springframework.cloud.stream.annotation.EnableBinding
+import org.springframework.cloud.stream.annotation.Input
+import org.springframework.cloud.stream.annotation.Output
+import org.springframework.cloud.stream.annotation.StreamListener
+import org.springframework.cloud.stream.messaging.Processor
+import org.springframework.messaging.Message
+import org.springframework.messaging.MessageChannel
+import org.springframework.messaging.handler.annotation.SendTo
+
+@EnableBinding(AccountChannel::class)
+class AccountProcess {
+
+    @StreamListener("accountIn")
+    @SendTo("accountOut")
+    fun transform(message: Message<String>): Message<String> {
+        println("account > request-id: $message, response-id: $message")
+        return message
+    }
+
+}
+
+interface AccountChannel {
+
+    @Input("accountIn")
+    fun accountInChannel(): MessageChannel
+
+    @Output("accountOut")
+    fun accountOutChannel(): MessageChannel
+}

--- a/src/main/kotlin/com/demo/nats/binder/SourceProcess.kt
+++ b/src/main/kotlin/com/demo/nats/binder/SourceProcess.kt
@@ -5,14 +5,15 @@ import org.springframework.cloud.stream.annotation.StreamListener
 import org.springframework.cloud.stream.messaging.Processor
 import org.springframework.messaging.handler.annotation.SendTo
 
-@EnableBinding(Processor::class)
+//@EnableBinding(Processor::class)
 class SourceProcess {
-
+    /*
     @StreamListener(Processor.INPUT)
     @SendTo(Processor.OUTPUT)
     fun transform(message: Any?): Any? {
         println("request-id: $message, response-id: $message")
         return message
     }
+     */
 
 }

--- a/src/main/kotlin/com/demo/nats/binder/UserProcess.kt
+++ b/src/main/kotlin/com/demo/nats/binder/UserProcess.kt
@@ -1,0 +1,31 @@
+package com.demo.nats.binder
+
+import org.springframework.cloud.stream.annotation.EnableBinding
+import org.springframework.cloud.stream.annotation.Input
+import org.springframework.cloud.stream.annotation.Output
+import org.springframework.cloud.stream.annotation.StreamListener
+import org.springframework.cloud.stream.messaging.Processor
+import org.springframework.messaging.Message
+import org.springframework.messaging.MessageChannel
+import org.springframework.messaging.handler.annotation.SendTo
+
+@EnableBinding(UserChannel::class)
+class UserProcess {
+
+    @StreamListener("userIn")
+    @SendTo("userOut")
+    fun transform(message: Message<String>): Message<String> {
+        println("user > request-id: $message, response-id: $message")
+        return message
+    }
+
+}
+
+interface UserChannel {
+
+    @Input("userIn")
+    fun userInChannel(): MessageChannel
+
+    @Output("userOut")
+    fun userOutChannel(): MessageChannel
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,15 +1,41 @@
+logging:
+  level:
+    org:
+      springframework:
+        cloud: DEBUG
+
 spring:
   cloud:
     stream:
       bindings:
-        input:
-          destination: dataIn
-          binder: nats
-        output:
-          destination: dataOut
-          binder: nats
-
-nats:
-  spring:
-    connectionname: nats
-    server: nats://localhost:4222
+        userIn:
+          destination: users.profile
+          binder: nats1
+        userOut:
+          destination: users.profile
+          binder: nats1
+        accountIn:
+          destination: account.register
+          binder: nats2
+        accountOut:
+          destination: account.register
+          binder: nats2
+      binders:
+        nats1:
+          type: nats
+          environment:
+            nats:
+              spring:
+                cloud:
+                  stream:
+                    binder:
+                      server: nats://localhost:4222
+        nats2:
+          type: nats
+          environment:
+            nats:
+              spring:
+                cloud:
+                  stream:
+                    binder:
+                      server: nats://localhost:4222

--- a/src/test/java/com/demo/nats/client/NatsTest.java
+++ b/src/test/java/com/demo/nats/client/NatsTest.java
@@ -5,8 +5,13 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.List;
 
 public class NatsTest {
+
+    private final List<String> ACCOUNT_DESTINATIONS = List.of("account.register");
+
+    private final List<String> USER_DESTINATIONS = List.of("users.profile");
 
     @Test
     void sendTest() throws Exception {
@@ -49,4 +54,25 @@ public class NatsTest {
         }
 
     }
+
+    @Test
+    void accountDestinationsTest() throws Exception {
+        //single URL
+        Connection nc = Nats.connect("nats://localhost:4222");
+        for (String destination : ACCOUNT_DESTINATIONS) {
+            Message message = nc.request(destination, destination.concat(" test").getBytes(StandardCharsets.UTF_8), Duration.ofSeconds(1000));
+            System.out.println(destination + " > " + new String(message.getData(), StandardCharsets.UTF_8));
+        }
+    }
+
+    @Test
+    void userDestinationsTest() throws Exception {
+        //single URL
+        Connection nc = Nats.connect("nats://localhost:4222");
+        for (String destination : USER_DESTINATIONS) {
+            Message message = nc.request(destination, destination.concat(" test").getBytes(StandardCharsets.UTF_8), Duration.ofSeconds(1000));
+            System.out.println(destination + " > " + new String(message.getData(), StandardCharsets.UTF_8));
+        }
+    }
+
 }


### PR DESCRIPTION
### Done
- custom `channel` 정의, `destination` 수/발신 테스트
- `connection` thread pool check
   `binder`에 정의한 `middleware` 를 사용시에 thread를 사용함

### Todo
- request path를 `channel` `destination(subject)` 관리 전략 필요